### PR TITLE
Change feature name from server to feature

### DIFF
--- a/features/org.wso2.carbon.identity.saml.common.util/pom.xml
+++ b/features/org.wso2.carbon.identity.saml.common.util/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.carbon.identity.saml.common.util.server.feature</artifactId>
+    <artifactId>org.wso2.carbon.identity.saml.common.util.feature</artifactId>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - SAML Common Util bundle Server Feature</name>
     <url>http://wso2.org</url>
@@ -53,7 +53,7 @@
                             <goal>p2-feature-gen</goal>
                         </goals>
                         <configuration>
-                            <id>org.wso2.carbon.identity.saml.common.util.server</id>
+                            <id>org.wso2.carbon.identity.saml.common.util.feature</id>
                             <propertiesFile>../etc/feature.properties</propertiesFile>
                             <bundles>
                                 <bundleDef>


### PR DESCRIPTION
Change the name of the feature from org.wso2.carbon.identity.saml.common.util.server to org.wso2.carbon.identity.saml.common.util.feature.