### PR TITLE
Fixed typo in id

### DIFF
--- a/features/org.wso2.carbon.identity.saml.common.util/pom.xml
+++ b/features/org.wso2.carbon.identity.saml.common.util/pom.xml
@@ -53,7 +53,7 @@
                             <goal>p2-feature-gen</goal>
                         </goals>
                         <configuration>
-                            <id>org.wso2.carbon.identity.saml.common.util.feature</id>
+                            <id>org.wso2.carbon.identity.saml.common.util</id>
                             <propertiesFile>../etc/feature.properties</propertiesFile>
                             <bundles>
                                 <bundleDef>


### PR DESCRIPTION
Fixed typo invalid configuration id which should be fixed to org.wso2.carbon.saml.common.util instead of org.wso2.carbon.identity.saml.common.util.feature.