### PR TITLE
Add xacml XMLObjectProviderInitializer initialization.

### DIFF
--- a/components/org.wso2.carbon.identity.saml.common.util/src/main/java/org/wso2/carbon/identity/saml/common/util/SAMLInitializer.java
+++ b/components/org.wso2.carbon.identity.saml.common.util/src/main/java/org/wso2/carbon/identity/saml/common/util/SAMLInitializer.java
@@ -79,6 +79,14 @@ public class SAMLInitializer {
                     .soap.config.XMLObjectProviderInitializer();
             soapXMLObjectProviderInitializer.init();
 
+            org.opensaml.xacml.profile.saml.config.XMLObjectProviderInitializer xacmlProfileXMLObjectProviderInitializer = new
+                    org.opensaml.xacml.profile.saml.config.XMLObjectProviderInitializer();
+            xacmlProfileXMLObjectProviderInitializer.init();
+
+            org.opensaml.xacml.config.XMLObjectProviderInitializer xacmlXMLObjectProviderInitializer = new
+                    org.opensaml.xacml.config.XMLObjectProviderInitializer();
+            xacmlXMLObjectProviderInitializer.init();
+
         } finally {
             thread.setContextClassLoader(originalClassLoader);
         }


### PR DESCRIPTION
## Purpose
> Needed for XACML use cases
>These are required to initialize the XACML related un-marshallers in openSAML3 library. Else will cause NPE's at runtime.